### PR TITLE
css filter属性加到html节点而不是body节点，解决position:fixed失效问题

### DIFF
--- a/include.php
+++ b/include.php
@@ -89,13 +89,13 @@ function live2d2_Path($file, $t = "path")
   $result = $zbp->$t . "zb_users/plugin/live2d2/";
   switch ($file) {
     case "css":
-      return $result . "var/css/live2d.css?v=2020-04-07";
+      return $result . "var/css/live2d.css?v=2023-06-24";
       break;
     case "js-live2d":
-      return $result . "var/js/live2d.js?v=2020-04-07";
+      return $result . "var/js/live2d.js?v=2023-06-24";
       break;
     case "js-message":
-      return $result . "var/js/message.js?v=2020-04-07";
+      return $result . "var/js/message.js?v=2023-06-24";
       break;
     case "u-json":
       return $result . "usr/message.json";

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <adapted>151626</adapted>
 <version>1.0</version>
 <pubdate>2018-09-15</pubdate>
-<modified>2020-04-07</modified>
+<modified>2023-06-24</modified>
 <price>0</price>
 <phpver>5.4</phpver>
 <advanced>

--- a/var/js/message.js
+++ b/var/js/message.js
@@ -296,7 +296,7 @@ if (!norunFlag) {
       if ($("#youduButton").hasClass("doudong")) {
         var typeIs = $("#youduButton").attr("data-type");
         $("#youduButton").removeClass("doudong");
-        $("body").removeClass(typeIs);
+        $("html").removeClass(typeIs);
         $("#youduButton").attr("data-type", "");
         // $("#landlord").removeAttr("style").fadeIn();
       } else {
@@ -306,7 +306,7 @@ if (!norunFlag) {
 
         $("#youduButton").addClass("doudong");
         $("#youduButton").attr("data-type", dataType);
-        $("body").addClass(dataType);
+        $("html").addClass(dataType);
         //$("#landlord").removeAttr("style").css({
         //top: $(window).scrollTop() + 137 + "px"
         //});


### PR DESCRIPTION
命中彩虹特效时，看板娘自动会跳到页面最底部，因为rainbow动画使用了filter属性。解决方案：
https://stackoverflow.com/questions/37949942/css-filter-cancels-element-position